### PR TITLE
Build and deploy image using Semaphore

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,23 @@
+#
+# CI pipeline for building the countingup/openjdk:8 Docker image and pushing to Docker Hub
+#
+name: Build and deploy image
+version: v1.0
+
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+
+blocks:
+  - name: Build and deploy image
+    task:
+      secrets:
+        - name: countingup-dockerhub
+      jobs:
+        - name: Build and deploy image
+          commands:
+            - checkout
+            - docker build -t countingup/openjdk:8 .
+            - echo "${DOCKERHUB_PASSWORD}" | docker login --username "${DOCKERHUB_USERNAME}" --password-stdin
+            - docker push countingup/openjdk:8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
 FROM adoptopenjdk/openjdk8:alpine
 
+LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-openjdk"
+
 RUN apk add --no-cache --update git openssh-client bash lftp coreutils curl


### PR DESCRIPTION
Use Semaphore to build the image and push to Docker Hub. Replaces Docker Hub's Autobuild, which is becoming unavailable on the free account tier.

Also add a label to the image that Snyk can use to monitor the repo.

[ch982]
