### PR TITLE
Rebuild to update base image for security vulns

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Includes:
 
 ## Changelog
 
+ - 2022-02-23 -- Rebuild to update base image for security vulns
  - 2022-02-09 -- Rebuild to update base image for security vulns
  - 2022-01-19 -- Rebuild to update base image for security vulns
  - 2021-11-06 -- Rebuild to update base image for security vulns


### PR DESCRIPTION
Introduced through: docker-image|countingup/openjdk@8 › expat/expat@2.4.4-r0

Resolves:
CVE-2022-25235
CVE-2022-25236
CVE-2022-25313
CVE-2022-25314
CVE-2022-25315