### PR TITLE
Rebuild to update dependencies to fix vulns

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Includes:
 
 ## Changelog
 
- - 2022-06-16 -- Rebuild to update base image for security vulns
+ - 2022-06-16 -- Rebuild to update dependencies for security vulns
  - 2022-04-13 -- Update busybox and git for security vulns
  - 2022-04-05 -- Update busybox for security vulns
  - 2022-03-23 -- Rebuild to update base image for security vulns

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Includes:
 
 ## Changelog
 
+ - 2022-06-16 -- Rebuild to update base image for security vulns
  - 2022-04-13 -- Update busybox and git for security vulns
  - 2022-04-05 -- Update busybox for security vulns
  - 2022-03-23 -- Rebuild to update base image for security vulns


### PR DESCRIPTION
No base image update, this rebuild updates the following dependencies with flagged vulns:
- `curl/curl@7.79.1-r0 -> curl/curl@7.79.1-r1`
- `pcre2/pcre2@10.36-r0 -> pcre2/pcre2@10.36-r1` via `git/git@2.32.1-r0 -> 2.32.2`


### Testing

Testing existing image: `snyk container test countingup/openjdk:8`
```
Base image:        alpine:3.14.6

Tested 42 dependencies for known issues, found 6 issues.

```

Testing local image after rebuild:
```
...
Base image:        alpine:3.14.6
...

✔ Tested 42 dependencies for known issues, no vulnerable paths found.
```