### PR TITLE
Rebuild and upgrade libssl1.1 & libcrypto1.1 for security vulns

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM adoptopenjdk/openjdk8:alpine
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-openjdk"
 
-RUN apk add --no-cache --update git openssh-client bash lftp coreutils curl busybox
+RUN apk add --no-cache --update --upgrade libssl1.1 libcrypto1.1 git openssh-client bash lftp coreutils curl busybox

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Includes:
 
 ## Changelog
 
+ - 2022-07-19 -- Rebuild and upgrade libssl1.1 & libcrypto1.1 for security vulns
  - 2022-07-04 -- Rebuild to update dependencies for security vulns
  - 2022-06-16 -- Rebuild to update dependencies for security vulns
  - 2022-04-13 -- Update busybox and git for security vulns


### PR DESCRIPTION
This upgrades ncurses-terminfo-base (new base image), libssl1.1 and libcrypto1.1:
```
/ # apk add --no-cache --update --upgrade libssl1.1 libcrypto1.1
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86_64/APKINDEX.tar.gz
fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86_64/APKINDEX.tar.gz
(1/2) Upgrading libcrypto1.1 (1.1.1n-r0 -> 1.1.1q-r0)
(2/2) Upgrading libssl1.1 (1.1.1n-r0 -> 1.1.1q-r0)
Executing ca-certificates-20211220-r0.trigger
Executing glibc-bin-2.33-r0.trigger
/usr/glibc-compat/sbin/ldconfig: /usr/glibc-compat/lib/ld-linux-x86-64.so.2 is not a symbolic link

OK: 42 MiB in 41 packages
```

This fixes:
 - https://www.cve.org/CVERecord?id=CVE-2022-29458 (https://security.snyk.io/vuln/SNYK-ALPINE314-NCURSES-2952571)
 - https://www.cve.org/CVERecord?id=CVE-2022-2097 (https://security.snyk.io/vuln/SNYK-ALPINE314-OPENSSL-2941807)