### PR TITLE
Rebuild for `git` security vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Includes:
 
 ## Changelog
 
+ - 2023-04-27 -- Rebuild to update base image for security vulnerability (git)
  - 2023-04-17 -- Rebuild to update base image for security vulnerability (curl)
  - 2023-04-05 -- Rebuild to update base image for security vulnerability (openssl)
  - 2023-03-27 -- Rebuild to update base image for security vulnerability (openssl)


### PR DESCRIPTION
```
Organization:      countingup
Package manager:   apk
Target file:       Dockerfile
Project name:      docker-image|cup
Docker image:      cup:openjdk
Platform:          linux/amd64
Base image:        adoptopenjdk/openjdk8:alpine
Licenses:          enabled

✓ Tested 42 dependencies for known issues, no vulnerable paths found.

Recommendations for your base image (adoptopenjdk/openjdk8:alpine) are not available.
See above for details and fixes on individual vulnerabilities
```