### PR TITLE
Switch to Eclipse Temurin which replaces AdoptOpenJDK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk8:alpine
+FROM eclipse-temurin:8-jdk-alpine
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-openjdk"
 


### PR DESCRIPTION
Eclipse Temurin, maintained by the Adoptium Working Group, is where
updates are currently being made, and AdoptOpenJDK is deprecated.

The AdoptOpenJDK image actually uses the Temurin Java binaries, but the Temurin image uses a more recent version of Alpine Linux.
