### PR TITLE
Revert "Switch to Eclipse Temurin which replaces AdoptOpenJDK (#23)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:8-jdk-alpine
+FROM adoptopenjdk/openjdk8:alpine
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-openjdk"
 


### PR DESCRIPTION
This reverts commit 174ea5bab9ec6122e52179a5bccab27daf17c1c2.

We're having some isses with the Temurin 8 JRE image, so revert to
AdoptOpenJDK.
