### PR TITLE
Use Amazon Corretto as alternative OpenJDK distribution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk8:alpine
+FROM amazoncorretto:8-alpine-jdk
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-openjdk"
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/countingup/openjdk.svg)](https://hub.docker.com/r/countingup/openjdk/builds/) ![Docker Image Size](https://img.shields.io/docker/image-size/countingup/openjdk/8)
 
-Minimal adoptopenjdk/openjdk8:alpine base image with a few tools useful in CI jobs.
+Minimal amazoncorretto:8-alpine-jdk base image with a few tools useful in CI jobs.
 
 Includes:
  - bash


### PR DESCRIPTION
We had issues using the Eclipse Temurin runtime base image, so try switching to Amazon Corretto instead (they have similar expected EOL of ~2026)