### PR TITLE
Rebuild to update curl/openssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Includes:
 
 ## Changelog
 
+ - 2024-01-04 -- Rebuild to update base image for security vulnerability (curl/openssh)
  - 2023-11-13 -- Upgrade libssl1.1 and libcrypto1.1 for security vulnerabilities
  - 2023-10-13 -- Rebuild to update base image for security vulnerability (curl/nghttp2)
  - 2023-09-27 -- Rebuild to update base image for security vulnerability (curl)


### PR DESCRIPTION
Fixes vulnerabilities in base image for CVE-2023-48795, CVE-2023-46218 and CVE-2023-46219.
