### PR TITLE
Rebuild image for security fixes (coreutils & openssl)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM amazoncorretto:8-alpine-jdk
 
 LABEL org.opencontainers.image.source="https://github.com/Countingup/docker-openjdk"
 
-RUN apk add --no-cache --update --upgrade libssl1.1 libcrypto1.1 git openssh-client bash lftp coreutils curl busybox
+RUN apk add --no-cache --update --upgrade git openssh-client bash lftp coreutils curl busybox

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Includes:
 
 ## Changelog
 
- - 2024-01-31 -- Rebuild to update base image for security vulnerability (coreutils/openssl)
+ - 2024-01-31 -- Rebuild to update base image for security vulnerability (coreutils/openssl) & remove explicit update to libssl and libcrypto
  - 2024-01-04 -- Rebuild to update base image for security vulnerability (curl/openssh)
  - 2023-11-13 -- Upgrade libssl1.1 and libcrypto1.1 for security vulnerabilities
  - 2023-10-13 -- Rebuild to update base image for security vulnerability (curl/nghttp2)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Includes:
 
 ## Changelog
 
+ - 2024-01-31 -- Rebuild to update base image for security vulnerability (coreutils/openssl)
  - 2024-01-04 -- Rebuild to update base image for security vulnerability (curl/openssh)
  - 2023-11-13 -- Upgrade libssl1.1 and libcrypto1.1 for security vulnerabilities
  - 2023-10-13 -- Rebuild to update base image for security vulnerability (curl/nghttp2)


### PR DESCRIPTION
Fixes:

- CVE-2024-0684 in coreutils
- CVE-2024-0727 & CVE-2023-6237 in openssl/libcrypto3

([snyk](https://app.snyk.io/org/countingup/project/f3b8f36e-7e69-4ff1-8670-6731785814eb))

This PR also removes the following packages from the update command: `libssl1.1` and `libcrypto1.1` as they no longer exist in the alpine v3.19 APK index.
